### PR TITLE
Add typescriptreact support

### DIFF
--- a/lua/syntax-tree-surfer/init.lua
+++ b/lua/syntax-tree-surfer/init.lua
@@ -425,11 +425,16 @@ end --}}}
 
 local function get_nodes_in_array() --{{{
 	local ts = vim.treesitter
-	local parser = ts.get_parser(0)
+	local current_buffer = vim.api.nvim_get_current_buf()
+
+	local ok, parser = pcall(ts.get_parser, 0)
+	if not ok and vim.bo[current_buffer].ft == "typescriptreact" then
+		parser = ts.get_parser(0, "tsx")
+	end
+
 	local trees = parser:parse()
 	local root = trees[1]:root()
 
-	local current_buffer = vim.api.nvim_get_current_buf()
 	local nodes = {}
 
 	recursive_child_iter(root, nodes)


### PR DESCRIPTION
When in a `typescriptreact` file, an error occurs when trying to use this plugin.

This is because `vim.treesitter.get_parser` takes a language as a second argument. However, there is no language argument that is given in this plugins source code. When no language is given, the filetype is taken to be the language. The problem here is that `typescriptreact` is not the name of the treesitter parser, it is actually `tsx`. 

I check whether the filetype is `typescriptreact` and if it is, then pass the language argument as `tsx`.

Note, this wasn't checked for `javascriptreact` and `jsx`. I don't think the same problem exists since the `javascriptreact` parser comes bundled with the `javascript` parser.