### PR TITLE
Add node holding and swapping feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,10 @@ require("syntax-tree-surfer").setup({
 
 # Version 2.2 Update
 
-### Hold and swap node
+### Hold and swap nodes
 // TODO: video demonstration //
+
+This feature allows marking a node and then it with another node.
 
 Example mappings for Version 2.2 functionalities:
 

--- a/README.md
+++ b/README.md
@@ -264,8 +264,8 @@ Example mappings for Version 2.2 functionalities:
 
 ```lua
 -- Hold a node for swapping
-vim.keymap.set("n", "gt", ":STSHoldFocusedNode<CR>", opts)
+vim.keymap.set("n", "gnh", ":STSHoldFocusedNode<CR>", opts)
 
 -- swap current node with held
-vim.keymap.set("n", "gT", ":STSSwapHeldAndFocusedNodes<CR>", opts)
+vim.keymap.set("n", "gns", ":STSSwapHeldAndFocusedNodes<CR>", opts)
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 1. [How do I install?](#how-do-i-install)
 1. [Version 1.1 Update](#version-11-update)
 1. [Version 2.0 Beta Update](#version-20-beta-update-)
+1. [Version 2.2 Update](#version-22-update-)
 
 # Version 1.0 Functionalities
 
@@ -252,3 +253,19 @@ require("syntax-tree-surfer").setup({
 ### Because every languages have different schemas and node-types, you can check the node-types that you're interested in with https://github.com/nvim-treesitter/playground
 
 #### You can also do a quick check using the command :STSPrintNodesAtCursor
+
+
+# Version 2.2 Update
+
+### Hold and swap node
+// TODO: video demonstration //
+
+Example mappings for Version 2.2 functionalities:
+
+```lua
+-- Hold a node for swapping
+vim.keymap.set("n", "gt", ":STSHoldFocusedNode<CR>", opts)
+
+-- swap current node with held
+vim.keymap.set("n", "gT", ":STSSwapHeldAndFocusedNodes<CR>", opts)
+```

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ require("syntax-tree-surfer").setup({
 ### Hold and swap nodes
 https://user-images.githubusercontent.com/8104435/225992362-4e82d677-2ff5-463a-a910-6a6bdbf4fc9c.mp4
 
-This feature allows marking a node and then it with another node.
+This feature allows marking a node and then swapping it with another node.
 
 Example mappings for Version 2.2 functionalities:
 
@@ -268,6 +268,9 @@ Example mappings for Version 2.2 functionalities:
 -- Hold a node for swapping
 vim.keymap.set("n", "gnh", "<cmd>STSHoldFocusedNode<cr>", opts)
 
--- swap current node with held
+-- Swap current node with held
 vim.keymap.set("n", "gns", "<cmd>STSSwapHeldAndFocusedNodes<cr>", opts)
+
+-- Alternatively, use a single binding for both:
+vim.keymap.set("n", "gnh", "<cmd>STSSwapOrHold<cr>", opts)
 ```

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 1. [Version 1.0 Functionalities](#version-10-functionalities)
 1. [How do I install?](#how-do-i-install)
 1. [Version 1.1 Update](#version-11-update)
-1. [Version 2.0 Beta Update](#version-20-beta-update-)
-1. [Version 2.2 Update](#version-22-update-)
+1. [Version 2.0 Beta Update](#version-20-beta-update)
+1. [Version 2.2 Update](#version-22-update)
 
 # Version 1.0 Functionalities
 

--- a/README.md
+++ b/README.md
@@ -262,15 +262,9 @@ https://user-images.githubusercontent.com/8104435/225992362-4e82d677-2ff5-463a-a
 
 This feature allows marking a node and then swapping it with another node.
 
-Example mappings for Version 2.2 functionalities:
+Example mapping:
 
 ```lua
--- Hold a node for swapping
-vim.keymap.set("n", "gnh", "<cmd>STSHoldFocusedNode<cr>", opts)
-
--- Swap current node with held
-vim.keymap.set("n", "gns", "<cmd>STSSwapHeldAndFocusedNodes<cr>", opts)
-
--- Alternatively, use a single binding for both:
+-- Holds a node, or swaps the held node
 vim.keymap.set("n", "gnh", "<cmd>STSSwapOrHold<cr>", opts)
 ```

--- a/README.md
+++ b/README.md
@@ -264,8 +264,8 @@ Example mappings for Version 2.2 functionalities:
 
 ```lua
 -- Hold a node for swapping
-vim.keymap.set("n", "gnh", ":STSHoldFocusedNode<CR>", opts)
+vim.keymap.set("n", "gnh", "<cmd>STSHoldFocusedNode<cr>", opts)
 
 -- swap current node with held
-vim.keymap.set("n", "gns", ":STSSwapHeldAndFocusedNodes<CR>", opts)
+vim.keymap.set("n", "gns", "<cmd>STSSwapHeldAndFocusedNodes<cr>", opts)
 ```

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ require("syntax-tree-surfer").setup({
 # Version 2.2 Update
 
 ### Hold and swap nodes
-// TODO: video demonstration //
+https://user-images.githubusercontent.com/8104435/225992362-4e82d677-2ff5-463a-a910-6a6bdbf4fc9c.mp4
 
 This feature allows marking a node and then it with another node.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The .go_to_top_node_and_execute_commands() method takes 2 arguments:
 
 1. boolean: if false then it will jump to the beginning of the node, if true it jumps to the end.
 
-1. lua table: a table that contains strings, each tring is a vim command example: { "normal! O", "normal! O", "startinsert" }
+1. lua table: a table that contains strings, each string is a vim command example: { "normal! O", "normal! O", "startinsert" }
 
 ---
 
@@ -267,4 +267,6 @@ Example mapping:
 ```lua
 -- Holds a node, or swaps the held node
 vim.keymap.set("n", "gnh", "<cmd>STSSwapOrHold<cr>", opts)
+-- Same for visual
+vim.keymap.set("x", "gnh", "<cmd>STSSwapOrHoldVisual<cr>", opts)
 ```

--- a/lua/syntax-tree-surfer/init.lua
+++ b/lua/syntax-tree-surfer/init.lua
@@ -875,7 +875,7 @@ local function hold_focused_node() --{{{
         local end_row, end_col = new_node:end_()
 
         --clear old extmark
-        if held_node.extmark_id then
+        if held_node and held_node.extmark_id then
             api.nvim_buf_del_extmark(0, ns, held_node.extmark_id)
         end
 
@@ -897,7 +897,7 @@ end --}}}
 local function swap_held_and_focused_node() --{{{
 	local bufnr = vim.api.nvim_get_current_buf()
 
-	if  held_node.bufnr == bufnr ~= nil then -- make sure we're swapping nodes in the same buffer
+	if  held_node ~= nil and held_node.bufnr == bufnr then -- make sure we're swapping nodes in the same buffer
 		ts_utils.swap_nodes(held_node.node, ts_utils.get_node_at_cursor(), bufnr, true)
         api.nvim_buf_del_extmark(0, ns, held_node.extmark_id) --clear the extmark, probably don't need it after this
 	end

--- a/lua/syntax-tree-surfer/init.lua
+++ b/lua/syntax-tree-surfer/init.lua
@@ -918,14 +918,6 @@ local function hold_or_swap() --{{{
     end
 end --}}}
 
-vim.api.nvim_create_user_command("STSHoldFocusedNode", function()
-	hold_focused_node()
-end, {})
-
-vim.api.nvim_create_user_command("STSSwapHeldAndFocusedNodes", function()
-    swap_held_and_focused_node()
-end, {})
-
 vim.api.nvim_create_user_command("STSSwapOrHold", function()
     hold_or_swap()
 end, {})

--- a/lua/syntax-tree-surfer/init.lua
+++ b/lua/syntax-tree-surfer/init.lua
@@ -874,7 +874,7 @@ M.hold_focused_node = function() --{{{
 
 	if new_node ~= nil then
         held_node = { node = new_node, buffer = bufnr }
-		print('held node')
+		print('held node at line ' .. new_node:start() + 1) -- node is zero based, lines start at 1
 	end
 end --}}}
 
@@ -884,8 +884,8 @@ end, {})
 
 vim.api.nvim_create_user_command("STSSwapFocusedWithHeld", function()
 	local bufnr = vim.api.nvim_get_current_buf()
-	if  bufnr ~= nil then
-		ts_utils.swap_nodes(ts_utils.get_node_at_cursor(), held_node.node, bufnr, true)
+	if  held_node.buffer == bufnr ~= nil then
+		ts_utils.swap_nodes(held_node.node, ts_utils.get_node_at_cursor(), bufnr, true)
 	end
 end, {})
 

--- a/lua/syntax-tree-surfer/init.lua
+++ b/lua/syntax-tree-surfer/init.lua
@@ -867,7 +867,7 @@ end, {})
 
 -- Spider's patch to hold nodes
 
-held_node = nil
+local held_node = nil
 M.hold_focused_node = function() --{{{
 	local new_node = ts_utils.get_node_at_cursor()
 	local bufnr = vim.api.nvim_get_current_buf()

--- a/lua/syntax-tree-surfer/init.lua
+++ b/lua/syntax-tree-surfer/init.lua
@@ -874,6 +874,11 @@ local function hold_focused_node() --{{{
 	if new_node ~= nil then
         local end_row, end_col = new_node:end_()
 
+        --clear old extmark
+        if held_node.extmark_id then
+            api.nvim_buf_del_extmark(0, ns, held_node.extmark_id)
+        end
+
         -- store the held node with extra data for checks/extmark deletion
         held_node = {
             node = new_node,
@@ -886,7 +891,6 @@ local function hold_focused_node() --{{{
                 8000
             )
         }
-        -- print('held node at line ' .. new_node:start() + 1) -- node is zero based, lines start at 1
 	end
 end --}}}
 

--- a/lua/syntax-tree-surfer/init.lua
+++ b/lua/syntax-tree-surfer/init.lua
@@ -900,7 +900,22 @@ local function swap_held_and_focused_node() --{{{
 	if  held_node ~= nil and held_node.bufnr == bufnr then -- make sure we're swapping nodes in the same buffer
 		ts_utils.swap_nodes(held_node.node, ts_utils.get_node_at_cursor(), bufnr, true)
         api.nvim_buf_del_extmark(0, ns, held_node.extmark_id) --clear the extmark, probably don't need it after this
+        held_node = nil
+    else
+        if held_node == nil then -- print out the reason for error
+            print("No held node!")
+        else
+            print("Incorrect buffer!")
+        end
 	end
+end --}}}
+
+local function hold_or_swap() --{{{
+    if held_node == nil then
+        hold_focused_node()
+    else
+        swap_held_and_focused_node()
+    end
 end --}}}
 
 vim.api.nvim_create_user_command("STSHoldFocusedNode", function()
@@ -909,6 +924,10 @@ end, {})
 
 vim.api.nvim_create_user_command("STSSwapHeldAndFocusedNodes", function()
     swap_held_and_focused_node()
+end, {})
+
+vim.api.nvim_create_user_command("STSSwapOrHold", function()
+    hold_or_swap()
 end, {})
 
 return M

--- a/lua/syntax-tree-surfer/init.lua
+++ b/lua/syntax-tree-surfer/init.lua
@@ -63,6 +63,54 @@ function M.update_selection(buf, node, selection_mode) -- rip from the old ts_ut
 	vim.fn.setpos(".", { buf, end_row, end_col, 0 })
 end --}}}
 
+local get_visual_node = function() --{{{
+	local node = ts_utils.get_node_at_cursor() -- declare node and bufnr
+
+	if node == nil then -- prevent errors
+		return
+	end
+
+    local nodeA = node
+    vim.cmd("normal! o")
+    local nodeB = ts_utils.get_node_at_cursor()
+    vim.cmd("normal! o")
+    local root = ts_utils.get_root_for_node(node)
+
+    if nodeA:id() ~= nodeB:id() then --> get the true node
+        local true_range = find_range_from_2nodes(nodeA, nodeB)
+        local parent = nodeA:parent()
+        local start_row_P, start_col_P, end_row_P, end_col_P = parent:range()
+
+        while
+            start_row_P ~= true_range[1]
+            or start_col_P ~= true_range[2]
+            or end_row_P ~= true_range[3]
+            or end_col_P ~= true_range[4]
+        do
+            if parent:parent() == nil then
+                break
+            end
+            parent = parent:parent()
+            start_row_P, start_col_P, end_row_P, end_col_P = parent:range()
+        end
+
+        node = parent
+    end
+
+    if node == root then -- catch some edge cases
+        node = nodeA
+    end
+
+	local parent = node:parent() --> if parent only has 1 child, move up the tree
+	while parent ~= nil and parent:named_child_count() == 1 do
+		node = parent
+		parent = node:parent()
+	end
+
+    return node
+
+end --}}}
+
 M.surf = function(direction, mode, move) --{{{
 	local node = ts_utils.get_node_at_cursor() -- declare node and bufnr
 	local bufnr = vim.api.nvim_get_current_buf()
@@ -71,44 +119,16 @@ M.surf = function(direction, mode, move) --{{{
 		return
 	end
 
-	if mode == "visual" then
-		local nodeA = node
-		vim.cmd("normal! o")
-		local nodeB = ts_utils.get_node_at_cursor()
-		vim.cmd("normal! o")
-		local root = ts_utils.get_root_for_node(node)
-
-		if nodeA:id() ~= nodeB:id() then --> get the true node
-			local true_range = find_range_from_2nodes(nodeA, nodeB)
-			local parent = nodeA:parent()
-			local start_row_P, start_col_P, end_row_P, end_col_P = parent:range()
-
-			while
-				start_row_P ~= true_range[1]
-				or start_col_P ~= true_range[2]
-				or end_row_P ~= true_range[3]
-				or end_col_P ~= true_range[4]
-			do
-				if parent:parent() == nil then
-					break
-				end
-				parent = parent:parent()
-				start_row_P, start_col_P, end_row_P, end_col_P = parent:range()
-			end
-
+	if mode == "visual" then-- {{{
+		node = get_visual_node()
+	else
+		local parent = node:parent()
+		while parent ~= nil and parent:named_child_count() == 1 do
 			node = parent
+			parent = node:parent()
 		end
+	end --}}}
 
-		if node == root then -- catch some edge cases
-			node = nodeA
-		end
-	end
-
-	local parent = node:parent() --> if parent only has 1 child, move up the tree
-	while parent ~= nil and parent:named_child_count() == 1 do
-		node = parent
-		parent = node:parent()
-	end
 
 	local target --> setting the target, depending on the direction
 	if direction == "parent" then
@@ -866,22 +886,22 @@ end, {})
 
 -- version 2.2
 
+
 local held_node = nil --store the held node internally
-local function hold_focused_node() --{{{
-	local new_node = ts_utils.get_node_at_cursor()
+local function hold_node(node) --{{{
 	local bufnr = vim.api.nvim_get_current_buf()
 
-	if new_node ~= nil then
-        local end_row, end_col = new_node:end_()
+	if node ~= nil then
+        local end_row, end_col = node:end_()
 
         --clear old extmark
         if held_node and held_node.extmark_id then
-            api.nvim_buf_del_extmark(0, ns, held_node.extmark_id)
+            -- api.nvim_buf_del_extmark(0, ns, held_node.extmark_id)
         end
 
         -- store the held node with extra data for checks/extmark deletion
         held_node = {
-            node = new_node,
+            node = node,
             bufnr = bufnr,
             extmark_id = set_extmark_then_delete_it( -- set the extmark and save it for deletion
                 end_row,
@@ -894,11 +914,11 @@ local function hold_focused_node() --{{{
 	end
 end --}}}
 
-local function swap_held_and_focused_node() --{{{
+local function swap_held_node(node) --{{{
 	local bufnr = vim.api.nvim_get_current_buf()
 
 	if  held_node ~= nil and held_node.bufnr == bufnr then -- make sure we're swapping nodes in the same buffer
-		ts_utils.swap_nodes(held_node.node, ts_utils.get_node_at_cursor(), bufnr, true)
+		ts_utils.swap_nodes(held_node.node, node, bufnr, true)
         api.nvim_buf_del_extmark(0, ns, held_node.extmark_id) --clear the extmark, probably don't need it after this
         held_node = nil
     else
@@ -910,16 +930,28 @@ local function swap_held_and_focused_node() --{{{
 	end
 end --}}}
 
-local function hold_or_swap() --{{{
+local function hold_or_swap(visual_mode) --{{{
     if held_node == nil then
-        hold_focused_node()
+		if visual_mode then
+			hold_node(get_visual_node())
+		else
+			hold_node(ts_utils.get_node_at_cursor())
+		end
     else
-        swap_held_and_focused_node()
+		if visual_mode then
+			swap_held_node(get_visual_node())
+		else
+			swap_held_node(ts_utils.get_node_at_cursor())
+		end
     end
 end --}}}
 
 vim.api.nvim_create_user_command("STSSwapOrHold", function()
-    hold_or_swap()
+    hold_or_swap(false)
+end, {})
+
+vim.api.nvim_create_user_command("STSSwapOrHoldVisual", function()
+    hold_or_swap(true)
 end, {})
 
 return M

--- a/lua/syntax-tree-surfer/init.lua
+++ b/lua/syntax-tree-surfer/init.lua
@@ -864,6 +864,30 @@ vim.api.nvim_create_user_command("STSPrintNodesAtCursor", function()
 	print_nodes_at_cursor()
 end, {})
 
-return M
 
+-- Spider's patch to hold nodes
+
+held_node = nil
+M.hold_focused_node = function() --{{{
+	local new_node = ts_utils.get_node_at_cursor()
+	local bufnr = vim.api.nvim_get_current_buf()
+
+	if new_node ~= nil then
+        held_node = { node = new_node, buffer = bufnr }
+		print('held node')
+	end
+end --}}}
+
+vim.api.nvim_create_user_command("STSHoldFocusedNode", function()
+	M.hold_focused_node()
+end, {})
+
+vim.api.nvim_create_user_command("STSSwapFocusedWithHeld", function()
+	local bufnr = vim.api.nvim_get_current_buf()
+	if  bufnr ~= nil then
+		ts_utils.swap_nodes(ts_utils.get_node_at_cursor(), held_node.node, bufnr, true)
+	end
+end, {})
+
+return M
 -- vim: foldmethod=marker foldmarker={{{,}}} foldlevel=0


### PR DESCRIPTION
I found myself needing to swap two nodes a far enough distance apart that sibling swapping was tedious, so I wrote small functions to 'hold' a node and then swap it with the focused node.
Notes:
- I chose the time the extmark exists arbitrarily and it may be better changed
- If you decide to merge this you may want to rerecord the demo because my vim is aesthetically jarringly different from the other demos