### PR TITLE
feat: expose `hold_or_swap` and `clear_held_node`

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,13 @@ vim.keymap.set("n", "gnh", "<cmd>STSSwapOrHold<cr>", opts)
 vim.keymap.set("x", "gnh", "<cmd>STSSwapOrHoldVisual<cr>", opts)
 ```
 
+The lower-level functionality can be accessed via:
+```lua
+require("syntax-tree-surfer").hold_or_swap(true) -- param is_visual boolean
+require("syntax-tree-surfer").clear_held_node()
+```
+note that `STSSwapOrHoldVisual` will clear the visual selection, but `hold_or_swap(true)` will not.
+
 # Special Thanks To:
 ### Dr. David A. Kunz for creating [Let's create a Neovim plugin using Treesitter and Lua](https://www.youtube.com/watch?v=dPQfsASHNkg)
 ### NVIM Treesitter Team - https://github.com/nvim-treesitter/nvim-treesitter

--- a/lua/syntax-tree-surfer/init.lua
+++ b/lua/syntax-tree-surfer/init.lua
@@ -952,7 +952,7 @@ local function swap_held_node(node) --{{{
 	end
 end --}}}
 
-local function hold_or_swap(visual_mode) --{{{
+M.hold_or_swap = function(visual_mode) --{{{
 	if held_node == nil then
 		if visual_mode then
 			hold_node(get_visual_node())
@@ -968,12 +968,19 @@ local function hold_or_swap(visual_mode) --{{{
 	end
 end --}}}
 
+M.clear_held_node = function()
+  if held_node and held_node.extmark_id then
+    api.nvim_buf_del_extmark(0, ns, held_node.extmark_id)
+  end
+  held_node = nil
+end
+
 vim.api.nvim_create_user_command("STSSwapOrHold", function()
-	hold_or_swap(false)
+	M.hold_or_swap(false)
 end, {})
 
 vim.api.nvim_create_user_command("STSSwapOrHoldVisual", function()
-	hold_or_swap(true)
+	M.hold_or_swap(true)
 	vim.cmd("norm! ")
 end, {})
 


### PR DESCRIPTION
This makes it easier to config on top of. For example, I am using `syntax-tree-surfer` with `hydra.nvim` and I want to stay in visual while holding and swapping, as well as clear the held node when exit the hydra.