### PR TITLE
fix: avoid global variable use

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,21 +53,21 @@ local opts = {noremap = true, silent = true}
 -- Normal Mode Swapping:
 -- Swap The Master Node relative to the cursor with it's siblings, Dot Repeatable
 vim.keymap.set("n", "vU", function()
-	vim.opt.opfunc = "v:lua.STSSwapUpNormal_Dot"
+	vim.opt.opfunc = "v:lua.require'syntax-tree-surfer'.STSSwapUpNormal_Dot"
 	return "g@l"
 end, { silent = true, expr = true })
 vim.keymap.set("n", "vD", function()
-	vim.opt.opfunc = "v:lua.STSSwapDownNormal_Dot"
+	vim.opt.opfunc = "v:lua.require'syntax-tree-surfer'.STSSwapDownNormal_Dot"
 	return "g@l"
 end, { silent = true, expr = true })
 
 -- Swap Current Node at the Cursor with it's siblings, Dot Repeatable
 vim.keymap.set("n", "vd", function()
-	vim.opt.opfunc = "v:lua.STSSwapCurrentNodeNextNormal_Dot"
+	vim.opt.opfunc = "v:lua.require'syntax-tree-surfer'.STSSwapCurrentNodeNextNormal_Dot"
 	return "g@l"
 end, { silent = true, expr = true })
 vim.keymap.set("n", "vu", function()
-	vim.opt.opfunc = "v:lua.STSSwapCurrentNodePrevNormal_Dot"
+	vim.opt.opfunc = "v:lua.require'syntax-tree-surfer'.STSSwapCurrentNodePrevNormal_Dot"
 	return "g@l"
 end, { silent = true, expr = true })
 

--- a/lua/syntax-tree-surfer/init.lua
+++ b/lua/syntax-tree-surfer/init.lua
@@ -327,7 +327,7 @@ vim.api.nvim_create_user_command("STSSwapPrevVisual", function()
 	M.surf("prev", "visual", true)
 end, {}) --}}}
 
--- Global Variables for Normal Swap Dot Repeat{{{
+-- Normal Swap Dot Repeat{{{
 M.STSSwapCurrentNodePrevNormal_Dot = function()
 	vim.cmd("STSSwapCurrentNodePrevNormal")
 end

--- a/lua/syntax-tree-surfer/init.lua
+++ b/lua/syntax-tree-surfer/init.lua
@@ -328,16 +328,16 @@ vim.api.nvim_create_user_command("STSSwapPrevVisual", function()
 end, {}) --}}}
 
 -- Global Variables for Normal Swap Dot Repeat{{{
-_G.STSSwapCurrentNodePrevNormal_Dot = function()
+M.STSSwapCurrentNodePrevNormal_Dot = function()
 	vim.cmd("STSSwapCurrentNodePrevNormal")
 end
-_G.STSSwapCurrentNodeNextNormal_Dot = function()
+M.STSSwapCurrentNodeNextNormal_Dot = function()
 	vim.cmd("STSSwapCurrentNodeNextNormal")
 end
-_G.STSSwapUpNormal_Dot = function()
+M.STSSwapUpNormal_Dot = function()
 	vim.cmd("STSSwapUpNormal")
 end
-_G.STSSwapDownNormal_Dot = function()
+M.STSSwapDownNormal_Dot = function()
 	vim.cmd("STSSwapDownNormal")
 end --}}}
 


### PR DESCRIPTION
fixes #22

this is an implementation with the least changes required, however, if you don't mind, I personally prefer to make all the original functions accessible directly, like this:
```lua
-- Swap in Normal Mode
vim.api.nvim_create_user_command("STSSwapUpNormal", function()
	M.move("n", true)
end, {})
-- Normal Swap Dot Repeat{{{
M.STSSwapUpNormal_Dot = function()
	vim.cmd("STSSwapUpNormal")
end
-- Swap The Master Node relative to the cursor with it's siblings, Dot Repeatable
vim.keymap.set("n", "vU", function()
	vim.opt.opfunc = "v:lua.require'syntax-tree-surfer'.STSSwapUpNormal_Dot"
	return "g@l"
end, { silent = true, expr = true })
```
↓↓↓
```lua
M.mk_repeatable = function(fname)
	return function()
		vim.go.opfunc = "v:lua.require'syntax-tree-surfer'." .. fname
		vim.cmd("normal! g@l")
	end
end


-- Swap in Normal Mode
M.STSSwapUpNormal = function()
	M.move("n", true)
end
vim.api.nvim_create_user_command("STSSwapUpNormal", M.STSSwapUpNormal, {})
-- Swap The Master Node relative to the cursor with it's siblings, Dot Repeatable
vim.keymap.set("n", "vU", require("syntax-tree-surfer").mk_repeatable("STSSwapUpNormal"), { silent = true })
```

So if you consider this a possibility, I can make those changes too

I simplified the approach taken by [gitsigns](https://github.com/lewis6991/gitsigns.nvim/blob/main/lua/gitsigns/repeat.lua)